### PR TITLE
Add IEEE 1752 Physical Activity Schema

### DIFF
--- a/Sources/OMHModels/DescriptiveStatistic.swift
+++ b/Sources/OMHModels/DescriptiveStatistic.swift
@@ -27,6 +27,6 @@ public enum DescriptiveStatistic: String, Schema {
     case thirdQuintile = "3rd quintile"
     case fourthQuintile = "4th quintile"
     
-    /// The Open mHealth schema identifier
+    /// The IEEE 1752 schema identifier
     public static let schemaId = SchemaId(namespace: .ieee, name: "descriptive-statistic", version: "1.0")
 }

--- a/Sources/OMHModels/DescriptiveStatisticDenominator.swift
+++ b/Sources/OMHModels/DescriptiveStatisticDenominator.swift
@@ -1,15 +1,16 @@
 //
 // This source file is part of the HealthKitOnOMH open source project
 //
-// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //
 // SPDX-License-Identifier: MIT
 
 
-/// An enumeration representing the denominator of the descriptive statistic when the measure has an implicit duration.
+/// The denominator of the descriptive statistic when the measures has an implicit duration. For example in the context of total sleep time, if the descriptive statistic is 'average' and the statistic denominator is 'd' the value describes average daily total sleep time during the period delimited by the effective time frame.
+/// Generated from IEEE 1752.1 `physical-activity-1.0` (https://w3id.org/ieee/ieee-1752-schema/descriptive-statistic-denominator.json)
 public enum DescriptiveStatisticDenominator: String, Schema {
     // swiftlint:disable identifier_name
-    // We disable this rule because we must use case names as defined by Open mHealth.
+    // We disable this rule because we must use case names as defined by IEEE 1752
     case d
     case wk
     case Mo
@@ -17,6 +18,6 @@ public enum DescriptiveStatisticDenominator: String, Schema {
     case meal
     case session
     
-    /// The Open mHealth schema identifier
-    public static let schemaId = SchemaId(namespace: .omh, name: "descriptive-statistic-denominator", version: "1.0")
+    /// The IEEE 1752 schema identifier
+    public static let schemaId = SchemaId(namespace: .ieee, name: "descriptive-statistic-denominator", version: "1.0")
 }

--- a/Sources/OMHModels/KcalUnit.swift
+++ b/Sources/OMHModels/KcalUnit.swift
@@ -1,0 +1,16 @@
+//
+// This source file is part of the OMHModels open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+
+/// Generated from IEEE 1752.1 `kcal-unit-value-1.0` (https://w3id.org/ieee/ieee-1752-schema/speed-unit-value.json)
+public typealias KcalUnitValue = TypedUnitValue<KcalUnit>
+
+public enum KcalUnit: String, UnitProtocol {
+    case kcal
+}

--- a/Sources/OMHModels/PhysicalActivity.swift
+++ b/Sources/OMHModels/PhysicalActivity.swift
@@ -1,0 +1,131 @@
+//
+// This source file is part of the OMHModels open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+
+/// A unit value that represents the number of repetitions of the activity base movement and the associated unit
+public typealias BaseMovementQuantityUnitValue = TypedUnitValue<BaseMovementQuantityUnit>
+
+/// Units for representing base movement
+public enum BaseMovementQuantityUnit: String, UnitProtocol {
+    case steps
+    case laps
+    case skips
+    case movements
+    case strokes
+}
+
+/// A unit value that represents the average rate at which the activity was performed and the associated unit
+public typealias AverageCadenceUnitValue = TypedUnitValue<AverageCadenceUnit>
+
+/// Units for representing the average rate at which activity was performed
+public enum AverageCadenceUnit: String, UnitProtocol {
+    case stepsPerMin = "steps/min"
+    case strokesPerMin = "strokes/min"
+    case skipsPerMin = "skips/min"
+    case lapsPerMin = "laps/min"
+    case movementsPerMin = "movements/min"
+    case strokesPerLap = "strokes/lap"
+}
+
+public enum ReportedActivityIntensity: String, Codable, Sendable {
+    case light
+    case moderate
+    case vigorous
+}
+
+
+/// Episode(s) of physical activity
+/// Generated from IEEE 1752.1 `physical-activity-1.0` (https://w3id.org/ieee/ieee-1752-schema/physical-activity.json)
+public struct PhysicalActivity: Schema {
+    /// The IEEE 1752 schema identifier
+    public static let schemaId = SchemaId(namespace: .omh, name: "physical-activity", version: "1.0")
+    
+    /// The name of the physical activity in which the person is engaged. This can be sedentary. It is recommended that the activity name be drawn from the latest CDC guidelines to facilitate mapping to standard energy expenditure values (METs) or other peer-reviewed source.
+    public var activityName: String
+    
+    /// Number of repetitions of the activity base movement, if applicable
+    public var baseMovementQuantity: BaseMovementQuantityUnitValue?
+    
+    /// The date-time at which, or time interval during which the measurement is asserted as being valid. As a measure of a duration, physical activity should not be associated to a date-time time frame. Hence, effective time frame is restricted to be a time interval.
+    public var effectiveTimeFrame: TimeFrame
+    
+    /// The distance covered, if applicable.
+    public var distance: LengthUnitValue?
+    
+    /// The total ascent, if applicable.
+    public var cumulativeElevationGain: LengthUnitValue?
+    
+    /// The net duration of the activity.
+    public var duration: DurationUnitValue?
+    
+    /// The duration of light-intensity physical activity.
+    public var durationLightActivity: DurationUnitValue?
+    
+    /// The duration of moderate-intensity physical activity.
+    public var durationModerateActivity: DurationUnitValue?
+    
+    /// The duration of vigorous-intensity physical activity.
+    public var durationVigorousActivity: DurationUnitValue?
+    
+    /// The average rate at which the activity was performed, if applicable. If none of the units listed applies, the string alternative will allow validation of the unlisted unit.
+    public var averageCadence: AverageCadenceUnitValue?
+    
+    /// The average speed at which the activity was performed, if applicable.
+    public var averageSpeed: SpeedUnitValue?
+    
+    /// The calories burned during the activity.
+    public var kcalBurned: KcalUnitValue?
+    
+    /// Self-reported intensity of the activity performed.
+    public var reportedActivityIntensity: ReportedActivityIntensity?
+    
+    /// Average Metabolic Equivalent of Task value for the activity. MET is defined as 3.5 mL\u00b7kg^\u22121\u00b7min^\u22121, often characterized as the metabolic cost of resting quietly.
+    public var metValue: Double?
+    
+    /// The descriptive statistic of a set of measurements (e.g., average, maximum) within the specified time frame.
+    public var descriptiveStatistic: DescriptiveStatistic?
+    
+    /// The denominator of the descriptive statistic when the measure has an implicit duration (e.g., if activity is 'walking', the descriptive statistic is 'average' and the statistic denominator is 'd' the measure describes the average daily measure of walking during the period delimited by the effective time frame).
+    public var descriptiveStatisticDenominator: DescriptiveStatisticDenominator?
+    
+    // swiftlint:disable function_default_parameter_at_end
+    // We disable this rule because the parameter order is based on the schema.
+    public init(
+        activityName: String,
+        baseMovementQuantity: BaseMovementQuantityUnitValue? = nil,
+        effectiveTimeFrame: TimeFrame,
+        distance: LengthUnitValue? = nil,
+        cumulativeElevationGain: LengthUnitValue? = nil,
+        duration: DurationUnitValue? = nil,
+        durationLightActivity: DurationUnitValue? = nil,
+        durationModerateActivity: DurationUnitValue? = nil,
+        durationVigorousActivity: DurationUnitValue? = nil,
+        averageCadence: AverageCadenceUnitValue? = nil,
+        averageSpeed: SpeedUnitValue? = nil,
+        kcalBurned: KcalUnitValue? = nil,
+        reportedActivityIntensity: ReportedActivityIntensity? = nil,
+        metValue: Double? = nil,
+        descriptiveStatistic: DescriptiveStatistic? = nil,
+        descriptiveStatisticDenominator: DescriptiveStatisticDenominator? = nil
+    ) {
+        self.activityName = activityName
+        self.baseMovementQuantity = baseMovementQuantity
+        self.effectiveTimeFrame = effectiveTimeFrame
+        self.distance = distance
+        self.cumulativeElevationGain = cumulativeElevationGain
+        self.duration = duration
+        self.durationLightActivity = durationLightActivity
+        self.durationModerateActivity = durationModerateActivity
+        self.durationVigorousActivity = durationVigorousActivity
+        self.averageCadence = averageCadence
+        self.averageSpeed = averageSpeed
+        self.kcalBurned = kcalBurned
+        self.reportedActivityIntensity = reportedActivityIntensity
+        self.metValue = metValue
+        self.descriptiveStatistic = descriptiveStatistic
+        self.descriptiveStatisticDenominator = descriptiveStatisticDenominator
+    }
+}

--- a/Sources/OMHModels/SpeedUnit.swift
+++ b/Sources/OMHModels/SpeedUnit.swift
@@ -1,0 +1,17 @@
+//
+// This source file is part of the OMHModels open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+
+/// Generated from IEEE 1752.1 `speed-unit-value-1.0` (https://w3id.org/ieee/ieee-1752-schema/speed-unit-value.json)
+public typealias SpeedUnitValue = TypedUnitValue<SpeedUnit>
+
+public enum SpeedUnit: String, UnitProtocol {
+    case metersPerSecond = "m/s"
+    case kilometersPerHour = "km/h"
+}

--- a/Tests/OMHModelsTests/PhysicalActivityTests.swift
+++ b/Tests/OMHModelsTests/PhysicalActivityTests.swift
@@ -1,0 +1,52 @@
+//
+// This source file is part of the HealthKitOnOMH open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+
+@testable import OMHModels
+import XCTest
+
+class PhysicalActivityTests: XCTestCase {
+    func testPhysicalActivity() {
+        // Create mock values
+        let mockBaseMovementQuantity = TypedUnitValue<BaseMovementQuantityUnit>(unit: .steps, value: 100)
+        let mockTimeFrame = TimeFrame(
+            timeInterval: TimeInterval(
+                startDateTime: DateTime(date: .now),
+                duration: DurationUnitValue(
+                    unit: TimeUnit.h,
+                    value: 1.0
+                )
+            )
+        )
+        let mockDistance = LengthUnitValue(unit: .m, value: 5.0)
+        let mockKcalBurned = KcalUnitValue(unit: .kcal, value: 500)
+        let mockDescriptiveStatistic = DescriptiveStatistic.average
+        let mockDescriptiveStatisticDenominator = DescriptiveStatisticDenominator.d
+        
+        // Initialize the PhysicalActivity struct
+        let activity = PhysicalActivity(
+            activityName: "Walking",
+            baseMovementQuantity: mockBaseMovementQuantity,
+            effectiveTimeFrame: mockTimeFrame,
+            distance: mockDistance,
+            kcalBurned: mockKcalBurned,
+            reportedActivityIntensity: .light,
+            metValue: 3.5,
+            descriptiveStatistic: mockDescriptiveStatistic,
+            descriptiveStatisticDenominator: mockDescriptiveStatisticDenominator
+        )
+        
+        XCTAssertEqual(activity.activityName, "Walking")
+        XCTAssertEqual(activity.baseMovementQuantity, mockBaseMovementQuantity)
+        XCTAssertEqual(activity.effectiveTimeFrame, mockTimeFrame)
+        XCTAssertEqual(activity.distance, mockDistance)
+        XCTAssertEqual(activity.kcalBurned, mockKcalBurned)
+        XCTAssertEqual(activity.reportedActivityIntensity, .light)
+        XCTAssertEqual(activity.metValue, 3.5)
+        XCTAssertEqual(activity.descriptiveStatistic, mockDescriptiveStatistic)
+        XCTAssertEqual(activity.descriptiveStatisticDenominator, mockDescriptiveStatisticDenominator)
+    }
+}


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign Digital Health Group open-source organization

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Add IEEE 1752 Physical Activity Schema

Adds the [IEEE 1752 Physical Activity](https://opensource.ieee.org/omh/1752/-/blob/main/schemas/physical_activity/physical-activity-1.0.json?ref_type=heads) schema to the package.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

